### PR TITLE
Add unix socket listening option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ sqlite3 bookstore.sqlite3 < examples/bookstore/data.sql
 ```
 $ echo -n "topsecret" > test.token
 $ sqlite-rest serve --auth-token-file test.token --security-allow-table books --db-dsn ./bookstore.sqlite3
-{"level":"info","ts":1672528510.825417,"logger":"db-server","caller":"sqlite-rest/server.go:121","msg":"server started","addr":":8080"}
+{"level":"info","ts":1672528510.825417,"logger":"db-server","msg":"server started","addr":":8080"}
 ... <omitted logs>
 ```
 
@@ -62,7 +62,7 @@ $ sqlite-rest serve --auth-token-file test.token --security-allow-table books --
 
 ```
 $ sqlite-rest serve --auth-token-file test.token --security-allow-table books --db-dsn ./bookstore.sqlite3 --http-socket /tmp/sqlite-rest.sock
-{"level":"info","ts":1672528510.825417,"logger":"db-server","caller":"sqlite-rest/server.go:121","msg":"server started","socket":"/tmp/sqlite-rest.sock"}
+{"level":"info","ts":1672528510.825417,"logger":"db-server","msg":"server started","socket":"/tmp/sqlite-rest.sock"}
 ... <omitted logs>
 ```
 


### PR DESCRIPTION
## Summary
- add support for listening on Unix domain sockets via a new `--http-socket` flag
- ensure the server starts, cleans up, and logs correctly when using a socket
- add automated coverage and documentation for socket-based serving

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955fcbf72a883319d62f6cfd43ea3ce)