### PR TITLE
Update Go toolchain to 1.24 and refresh CI actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,14 +10,14 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [">=1.21"]
+        go-version: ["1.24.x"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Test

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -29,12 +29,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v5
         with:
           file: ./Dockerfile.server
           push: true

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.24 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/b4fun/sqlite-rest
 
-go 1.21
+go 1.24
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1


### PR DESCRIPTION
## Summary
- bump the Go toolchain to version 1.24 for the module and Docker builder
- refresh GitHub Actions workflows to use current action versions and Go 1.24.x matrix

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69578b9c49ac8331b6eed0f307a859f9)